### PR TITLE
Fix backend flow validation and provider encryption tests

### DIFF
--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -7,7 +7,7 @@ import litellm
 from litellm import acompletion, completion_cost
 
 from ..models import LLMProvider
-from ..utils.encryption import decrypt_api_key
+from ..utils.encryption import decrypt_api_key, encrypt_api_key
 
 
 class LLMService:
@@ -205,8 +205,6 @@ class LLMService:
         Raises:
             HTTPException: If creation fails
         """
-        from ..utils.encryption import encrypt_api_key
-
         # Encrypt API key if provided
         encrypted_key = None
         if api_key:


### PR DESCRIPTION
## Summary
- ensure flow validation collects executable errors alongside basic validation and better detects unreachable nodes
- expose encrypt_api_key at the module level so LLM provider tests can patch it

## Testing
- pytest tests/unit -v

------
https://chatgpt.com/codex/tasks/task_e_68e3b76f44b0832d9e3fe1b2c55d2300