### PR TITLE
Fix frontend lint configuration and hook dependencies

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/frontend/src/app/crews/page.tsx
+++ b/frontend/src/app/crews/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 import CrewBuilder from '@/components/crews/CrewBuilder';
@@ -20,11 +20,7 @@ export default function CrewsPage() {
   const [editingCrewId, setEditingCrewId] = useState<number | undefined>();
   const [editingAgentId, setEditingAgentId] = useState<number | undefined>();
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     setLoading(true);
     try {
       const [crewsResponse, agentsResponse] = await Promise.all([
@@ -43,7 +39,11 @@ export default function CrewsPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [setAgents, setCrews]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const handleCreateCrew = () => {
     setEditingCrewId(undefined);
@@ -67,12 +67,12 @@ export default function CrewsPage() {
 
   const handleSaveCrew = (crewId: number) => {
     setShowCrewBuilder(false);
-    loadData();
+    void loadData();
   };
 
   const handleSaveAgent = (agentId: number) => {
     setShowAgentForm(false);
-    loadData();
+    void loadData();
   };
 
   if (showCrewBuilder) {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 import Dashboard from '@/components/dashboard/Dashboard';
 import { apiClient } from '@/lib/api-client';
@@ -15,11 +15,7 @@ export default function DashboardPage() {
 
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    loadDashboardData();
-  }, []);
-
-  const loadDashboardData = async () => {
+  const loadDashboardData = useCallback(async () => {
     setLoading(true);
     try {
       // Load all data in parallel
@@ -41,7 +37,11 @@ export default function DashboardPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [setAgents, setCrews, setExecutions, setFlows, setTools]);
+
+  useEffect(() => {
+    void loadDashboardData();
+  }, [loadDashboardData]);
 
   return (
     <ProtectedRoute>

--- a/frontend/src/app/executions/[id]/page.tsx
+++ b/frontend/src/app/executions/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 import ExecutionDetail from '@/components/executions/ExecutionDetail';
@@ -17,11 +17,7 @@ export default function ExecutionPage() {
   const [loading, setLoading] = useState(true);
   const [cancelling, setCancelling] = useState(false);
 
-  useEffect(() => {
-    loadExecution();
-  }, [executionId]);
-
-  const loadExecution = async () => {
+  const loadExecution = useCallback(async () => {
     setLoading(true);
     try {
       const response = await apiClient.get(`/api/v1/executions/${executionId}`);
@@ -33,7 +29,11 @@ export default function ExecutionPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [executionId]);
+
+  useEffect(() => {
+    void loadExecution();
+  }, [loadExecution]);
 
   const handleCancel = async () => {
     if (!execution || execution.status !== 'running') return;

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import ProtectedRoute from '@/components/auth/ProtectedRoute';
 import ToolRegistry from '@/components/tools/ToolRegistry';
 import ToolForm from '@/components/tools/ToolForm';
@@ -13,11 +13,7 @@ export default function ToolsPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingToolId, setEditingToolId] = useState<number | undefined>();
 
-  useEffect(() => {
-    loadTools();
-  }, []);
-
-  const loadTools = async () => {
+  const loadTools = useCallback(async () => {
     setLoading(true);
     try {
       const response = await apiClient.get('/api/v1/tools');
@@ -29,7 +25,11 @@ export default function ToolsPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [setTools]);
+
+  useEffect(() => {
+    void loadTools();
+  }, [loadTools]);
 
   const handleCreateTool = () => {
     setEditingToolId(undefined);
@@ -43,7 +43,7 @@ export default function ToolsPage() {
 
   const handleSaveTool = () => {
     setShowForm(false);
-    loadTools();
+    void loadTools();
   };
 
   if (showForm) {

--- a/frontend/src/components/flows/FlowCanvas.tsx
+++ b/frontend/src/components/flows/FlowCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, DragEvent, useRef, useMemo } from 'react';
+import { useCallback, useEffect, DragEvent, useRef } from 'react';
 import ReactFlow, {
   Background,
   Controls,
@@ -50,7 +50,7 @@ function FlowCanvasInner({ flowId, readOnly = false, onNodeSelect }: FlowCanvasP
   const { currentFlow, updateFlow } = useFlowStore();
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { screenToFlowPosition } = useReactFlow();
-  let nodeIdCounter = useRef(1);
+  const nodeIdCounter = useRef(1);
 
   // Convert API FlowNode to ReactFlow Node
   const convertToReactFlowNodes = useCallback((flowNodes: FlowNode[]): Node[] => {
@@ -86,7 +86,7 @@ function FlowCanvasInner({ flowId, readOnly = false, onNodeSelect }: FlowCanvasP
       setNodes(convertToReactFlowNodes(currentFlow.nodes));
       setEdges(convertToReactFlowEdges(currentFlow.edges || []));
     }
-  }, [currentFlow?.id, convertToReactFlowNodes, convertToReactFlowEdges, setNodes, setEdges]);
+  }, [convertToReactFlowEdges, convertToReactFlowNodes, currentFlow, setEdges, setNodes]);
 
   // Sync nodes/edges changes back to store (with debounce to avoid loops)
   useEffect(() => {
@@ -118,7 +118,7 @@ function FlowCanvasInner({ flowId, readOnly = false, onNodeSelect }: FlowCanvasP
     }, 300); // 300ms debounce
 
     return () => clearTimeout(timeoutId);
-  }, [nodes, edges, currentFlow?.id, readOnly, updateFlow]);
+  }, [currentFlow, edges, nodes, readOnly, updateFlow]);
 
   // Handle new connections
   const onConnect: OnConnect = useCallback(


### PR DESCRIPTION
## Summary
- add an explicit Next.js ESLint configuration so linting can run non-interactively in CI
- wrap data-loading helpers in useCallback and invoke them via effects to satisfy React hook dependency lint rules
- update FlowCanvas effect dependencies to reflect the values used inside the effects

## Testing
- npm run lint
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e3be801d68832d8fe2d687125fc6e9